### PR TITLE
Added new select all / unselect all feature

### DIFF
--- a/Source/CompanyCommunicator/ClientApp/public/locales/en-US/translation.json
+++ b/Source/CompanyCommunicator/ClientApp/public/locales/en-US/translation.json
@@ -120,5 +120,8 @@
   "CardTitle": "Card Title",
   "CardImage": "Card Image",
   "TargetGroups": "Target Groups",
-  "CSVIsTooBig": "The CSV is too big. Needs to be smaller than: "
+  "CSVIsTooBig": "The CSV is too big. Needs to be smaller than: ",
+  "SelectAll": "Select all",
+  "UnselectAll": "Unselect all",
+  "MaxTeamsError": "You are trying to send the message to too many teams. Please select fewer teams and try again."
 }

--- a/Source/CompanyCommunicator/ClientApp/src/components/NewMessage/newMessage.scss
+++ b/Source/CompanyCommunicator/ClientApp/src/components/NewMessage/newMessage.scss
@@ -117,6 +117,11 @@
             }
         }
 
+        .selectTeamsContainer {
+            margin: 1.1rem;
+            padding-left: 1.4rem;
+        }
+
         .footerContainer {
             position: fixed;
             bottom: 0;

--- a/Source/CompanyCommunicator/Controllers/DraftNotificationsController.cs
+++ b/Source/CompanyCommunicator/Controllers/DraftNotificationsController.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Controllers
                 throw new ArgumentNullException(nameof(notification));
             }
 
-            if (!notification.Validate(this.localizer, out string errorMessage))
+            if (!notification.Validate(this.localizer, out string errorMessage, this.userAppOptions.MaxNumberOfTeams))
             {
                 return this.BadRequest(errorMessage);
             }
@@ -206,7 +206,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Controllers
                 return this.Forbid();
             }
 
-            if (!notification.Validate(this.localizer, out string errorMessage))
+            if (!notification.Validate(this.localizer, out string errorMessage, this.userAppOptions.MaxNumberOfTeams))
             {
                 return this.BadRequest(errorMessage);
             }

--- a/Source/CompanyCommunicator/Controllers/Options/UserAppOptions.cs
+++ b/Source/CompanyCommunicator/Controllers/Options/UserAppOptions.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Controllers.Options
         /// <summary>
         /// Gets or sets a value indicating whether get or sets a value indicating if the tracking is disabled or not.
         /// </summary>
-        public bool DisableReadTracking { get; set; } 
+        public bool DisableReadTracking { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of teams you can select to receive a message.
+        /// </summary>
+        public int MaxNumberOfTeams { get; set; }
     }
 }

--- a/Source/CompanyCommunicator/Controllers/OptionsController.cs
+++ b/Source/CompanyCommunicator/Controllers/OptionsController.cs
@@ -1,0 +1,35 @@
+﻿namespace Microsoft.Teams.Apps.CompanyCommunicator.Controllers
+{
+    using System;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Options;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Controllers.Options;
+
+    /// <summary>
+    /// Controller for ptions.
+    /// </summary>
+    [Route("api/options")]
+    public class OptionsController : ControllerBase
+    {
+        private readonly UserAppOptions userAppOptions;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OptionsController"/> class.
+        /// </summary>
+        /// <param name="userAppOptions">the user app options.</param>
+        public OptionsController(IOptions<UserAppOptions> userAppOptions)
+        {
+            this.userAppOptions = userAppOptions?.Value ?? throw new ArgumentNullException(nameof(userAppOptions));
+        }
+
+        /// <summary>
+        /// Returns the maximum number of teams that can receive a message.
+        /// </summary>
+        /// <returns>The maximun number of teams that can receive a message.</returns>
+        [HttpGet]
+        public ActionResult<string> GetMaxNumberOfTeams()
+        {
+            return this.Ok(this.userAppOptions.MaxNumberOfTeams);
+        }
+    }
+}

--- a/Source/CompanyCommunicator/Models/DraftNotification.cs
+++ b/Source/CompanyCommunicator/Models/DraftNotification.cs
@@ -65,36 +65,37 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Models
 
         /// <summary>
         /// Validates a draft notification.
-        /// Teams and Rosters property should not contain more than 20 items.
+        /// Teams and Rosters property should not contain more than the maximum number of items defined in the app settings.
         /// </summary>
         /// <param name="localizer">The string localizer service.</param>
         /// <param name="errorMessage">It returns the error message found by the method to the callers.</param>
+        /// <param name="maxSelectedTeamNum">The maximum number of supported teams that can receive a message.</param>
         /// <returns>A flag indicates if a draft notification is valid or not.</returns>
-        public bool Validate(IStringLocalizer<Strings> localizer, out string errorMessage)
+        public bool Validate(IStringLocalizer<Strings> localizer, out string errorMessage, int maxSelectedTeamNum)
         {
             var stringBuilder = new StringBuilder();
 
             var teams = this.Teams.ToList();
-            if (teams.Count > DraftNotification.MaxSelectedTeamNum)
+            if (teams.Count > maxSelectedTeamNum)
             {
                 var format = localizer.GetString("NumberOfTeamsExceededLimitWarningFormat");
-                stringBuilder.AppendFormat(format, teams.Count, DraftNotification.MaxSelectedTeamNum);
+                stringBuilder.AppendFormat(format, teams.Count, maxSelectedTeamNum);
                 stringBuilder.AppendLine();
             }
 
             var rosters = this.Rosters.ToList();
-            if (rosters.Count > DraftNotification.MaxSelectedTeamNum)
+            if (rosters.Count > maxSelectedTeamNum)
             {
                 var format = localizer.GetString("NumberOfRostersExceededLimitWarningFormat");
-                stringBuilder.AppendFormat(format, rosters.Count, DraftNotification.MaxSelectedTeamNum);
+                stringBuilder.AppendFormat(format, rosters.Count, maxSelectedTeamNum);
                 stringBuilder.AppendLine();
             }
 
             var groups = this.Groups.ToList();
-            if (groups.Count > DraftNotification.MaxSelectedTeamNum)
+            if (groups.Count > maxSelectedTeamNum)
             {
                 var format = localizer.GetString("NumberOfGroupsExceededLimitWarningFormat");
-                stringBuilder.AppendFormat(format, groups.Count, DraftNotification.MaxSelectedTeamNum);
+                stringBuilder.AppendFormat(format, groups.Count, maxSelectedTeamNum);
                 stringBuilder.AppendLine();
             }
 

--- a/Source/CompanyCommunicator/Startup.cs
+++ b/Source/CompanyCommunicator/Startup.cs
@@ -137,6 +137,8 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator
 
                     options.DisableReadTracking =
                         configuration.GetValue<bool>("DisableReadTracking", false);
+
+                    options.MaxNumberOfTeams = configuration.GetValue<int>("MaxNumberOfTeams", 20);
                 });
 
             services.AddOptions();

--- a/Source/CompanyCommunicator/appsettings.json
+++ b/Source/CompanyCommunicator/appsettings.json
@@ -27,6 +27,7 @@
   "AuthorizedCreatorUpns": "[upn list]",
   "DisableTenantFilter": "false",
   "AllowedTenants": "[tenant list]",
+  "MaxNumberOfTeams": 20,
   "ForceCompleteMessageDelayInSeconds": "86400",
   "DisableReadTracking": false,
   "ImageUploadBlobStorage": true,

--- a/Source/Test/CompanyCommunicator.Test/Controllers/DraftNotificationsControllerTest.cs
+++ b/Source/Test/CompanyCommunicator.Test/Controllers/DraftNotificationsControllerTest.cs
@@ -1017,6 +1017,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Test.Controllers
             this.userAppOptions.Setup(x => x.Value).Returns(new UserAppOptions(){ImageUploadBlobStorage = this.imageUploadBlobStorage});
             this.notificationDataRepository.Setup(x => x.TableRowKeyGenerator).Returns(new TableRowKeyGenerator());
             this.notificationDataRepository.Setup(x => x.TableRowKeyGenerator.CreateNewKeyOrderingOldestToMostRecent()).Returns(this.notificationId);
+            this.userAppOptions.Setup(x => x.Value).Returns(new UserAppOptions() { MaxNumberOfTeams = 20 });
             var controller = new DraftNotificationsController(this.notificationDataRepository.Object, this.teamDataRepository.Object, this.draftNotificationPreviewService.Object, this.appSettingsService.Object, this.localizer.Object, this.groupsService.Object, this.storageClientFactory.Object, this.userAppOptions.Object);
             var user = new ClaimsPrincipal(new ClaimsIdentity());
             controller.ControllerContext = new ControllerContext();


### PR DESCRIPTION
This PR adds a new feature to Company Communicator. When you compose a new message, now you have the ability to quickly select or unselect all the teams that will receive it. The maximum number of teams that can be selected is controlled by a new setting in the appsettings.json of the application, called MaxNumberOfTeams. If the setting doesn't exist, the default value is 20, which is the same limit currently hardcoded in code. 

![CompanyCommunicator-MaxTeams](https://user-images.githubusercontent.com/1230332/167365695-636eea03-77d5-4886-8df5-9c0ecdf90aac.gif)
